### PR TITLE
allow unfree packages

### DIFF
--- a/bases/devbox/Dockerfile
+++ b/bases/devbox/Dockerfile
@@ -4,6 +4,7 @@ RUN wget https://github.com/jetpack-io/devbox/releases/download/0.1.0/devbox_0.1
     tar -xzvf devbox_0.1.0_linux_amd64.tar.gz && \
     chmod +x devbox && \
     mv devbox /usr/bin
+ENV NIXPKGS_ALLOW_UNFREE=1
 ENV PATH=/usr/bin:$PATH
 WORKDIR /code
 COPY devbox.json devbox.json


### PR DESCRIPTION
Working with Marty, we found this allows us to install vscode without a hitch:

```
$ devbox add vscode
```

Signed-off-by: vsoch <vsoch@users.noreply.github.com>